### PR TITLE
uber apk signer fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The Rabbit R1 Launcher Project aims to adapt the Rabbit R1 Launcher for use acro
 ### Requirements
 - **Java:** Ensure Java is installed on your system. Java is used primarily for signing the APKs and should not be used to modify the Smali directly.
 - **Apktool:** For building and reversing Android APKs. Install Apktool from [Apktool official page](https://ibotpeaches.github.io/Apktool/install/).
-- **Uber APK Signer:** This tool is used for signing the built APKs. Download it from [its GitHub repository](https://github.com/patrickfav/uber-apk-signer). (rename file to ```uber-apk-signer.jar``` and place into the cloned repository)
+- **Uber APK Signer:** This tool is used for signing the built APKs. Download it from [its GitHub repository](https://github.com/patrickfav/uber-apk-signer).
+  (rename file to ```uber-apk-signer.jar``` and place into the cloned repository)
 - **jadx:** A Dex to Java decompiler. Install jadx from [GitHub](https://github.com/skylot/jadx).
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Rabbit R1 Launcher Project aims to adapt the Rabbit R1 Launcher for use acro
 ### Requirements
 - **Java:** Ensure Java is installed on your system. Java is used primarily for signing the APKs and should not be used to modify the Smali directly.
 - **Apktool:** For building and reversing Android APKs. Install Apktool from [Apktool official page](https://ibotpeaches.github.io/Apktool/install/).
-- **Uber APK Signer:** This tool is used for signing the built APKs. Download it from [its GitHub repository](https://github.com/patrickfav/uber-apk-signer).
+- **Uber APK Signer:** This tool is used for signing the built APKs. Download it from [its GitHub repository](https://github.com/patrickfav/uber-apk-signer). (rename file to ```uber-apk-signer.jar``` and place into the cloned repository)
 - **jadx:** A Dex to Java decompiler. Install jadx from [GitHub](https://github.com/skylot/jadx).
 
 ### Usage

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ esac
 apktool b "${build_type}/smali" -o "${build_type}/apk/Rabbit R1 ${build_type}.apk"
 
 # Sign the APK
-java -jar "/Users/Andrew/Downloads/Uber APK Signer 1.jar" --apks "${build_type}/apk/Rabbit R1 ${build_type}.apk"
+java -jar "./uber-apk-signer.jar" --apks "${build_type}/apk/Rabbit R1 ${build_type}.apk"
 
 # Rename the signed APK
 mv "${build_type}/apk/Rabbit R1 ${build_type}-aligned-debugSigned.apk" "${build_type}/apk/Rabbit R1 ${build_type}.apk"


### PR DESCRIPTION
I have already seen someone making an issue about this.
The bash script has an absolute file path to the uber jar file.
This script therefore wouldn't work without changing this on any other PC.
So I just added the instructions to the readme that the uber jar file should be placed inside of the cloned repository and I changed the line to work with a relative path.